### PR TITLE
Fixed template reference deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog references the relevant changes (bug and security fixes) done.
 To get the diff for a specific change, go to https://github.com/freshheads/FHCookieGuardBundle/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/freshheads/FHCookieGuardBundle/compare/1.1.0...1.2.0
 
+* __1.2.1__ ([code comparison](https://github.com/freshheads/FHCookieGuardBundle/compare/1.2.0...1.2.1))
+
+  * Fixed Twig template reference deprecation
+
 * __1.2.0__ ([code comparison](https://github.com/freshheads/FHCookieGuardBundle/compare/1.1.0...1.2.0))
 
   * Dropped PHP 5.6 support, minimal required PHP version 7.1.3 

--- a/Twig/CookieGuardExtension.php
+++ b/Twig/CookieGuardExtension.php
@@ -40,7 +40,7 @@ class CookieGuardExtension extends AbstractExtension
 
     public function showIfCookieAccepted(string $content): string
     {
-        return $this->twig->render('FHCookieGuardBundle:CookieGuard:cookieGuardedContent.html.twig', [
+        return $this->twig->render('@FHCookieGuard/CookieGuard/cookieGuardedContent.html.twig', [
             'content' => $content,
             'show' => $this->cookieSettingsAreAccepted()
         ]);


### PR DESCRIPTION
`Template reference "FHCookieGuardBundle:CookieGuard:cookieGuardedContent.html.twig" not found, did you mean "@FHCookieGuard/CookieGuard/cookieGuardedContent.html.twig"?`